### PR TITLE
Add clipboard-based import/export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS
+
+This repository contains a minimal Figma plugin written in TypeScript.
+
+## Development guidelines
+
+- Keep the TypeScript source in `src/` and compiled output in `dist/`.
+- After making changes, run `npm install` if needed, then `npm run build` to compile the plugin.
+- Commit both the `src` and `dist` folders so the plugin can be used without building.
+- Run `npm test` to execute any tests (currently none).
+- Use two spaces for indentation in TypeScript and HTML files.
+- Ensure `manifest.json` points to the compiled files in `dist/`.

--- a/dist/code.js
+++ b/dist/code.js
@@ -1,0 +1,93 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+figma.showUI(__html__, { width: 400, height: 300 });
+figma.ui.onmessage = (msg) => __awaiter(void 0, void 0, void 0, function* () {
+    if (msg.type === 'export') {
+        const node = figma.currentPage.selection[0];
+        if (!node) {
+            figma.ui.postMessage({ type: 'error', message: 'Select a node to export' });
+            return;
+        }
+        const data = nodeToJSON(node);
+        figma.ui.postMessage({ type: 'exported', data });
+    }
+    else if (msg.type === 'import') {
+        const data = msg.data;
+        try {
+            const node = jsonToNode(data);
+            figma.currentPage.appendChild(node);
+            figma.ui.postMessage({ type: 'imported' });
+        }
+        catch (e) {
+            figma.ui.postMessage({ type: 'error', message: 'Import failed' });
+        }
+    }
+    else if (msg.type === 'close') {
+        figma.closePlugin();
+    }
+});
+function nodeToJSON(node) {
+    const obj = {
+        id: node.id,
+        type: node.type,
+        name: node.name,
+    };
+    if ('width' in node)
+        obj.width = node.width;
+    if ('height' in node)
+        obj.height = node.height;
+    if ('fills' in node)
+        obj.fills = clone(node.fills);
+    if ('characters' in node)
+        obj.characters = node.characters;
+    if ('children' in node) {
+        obj.children = [];
+        for (const child of node.children) {
+            obj.children.push(nodeToJSON(child));
+        }
+    }
+    return obj;
+}
+function jsonToNode(obj) {
+    let node;
+    switch (obj.type) {
+        case 'RECTANGLE':
+            node = figma.createRectangle();
+            break;
+        case 'TEXT':
+            node = figma.createText();
+            if (obj.characters)
+                node.characters = obj.characters;
+            break;
+        case 'COMPONENT':
+            node = figma.createComponent();
+            break;
+        case 'FRAME':
+        default:
+            node = figma.createFrame();
+            break;
+    }
+    node.name = obj.name || '';
+    if ('width' in obj && 'height' in obj && 'resize' in node)
+        node.resize(obj.width, obj.height);
+    if ('fills' in obj)
+        node.fills = obj.fills;
+    if (obj.children && 'appendChild' in node) {
+        for (const childObj of obj.children) {
+            const child = jsonToNode(childObj);
+            node.appendChild(child);
+        }
+    }
+    return node;
+}
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}

--- a/dist/ui.html
+++ b/dist/ui.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body { font-family: sans-serif; }
+  </style>
+</head>
+<body>
+  <h3>Raw Component Export/Import</h3>
+  <button id="exportBtn">Copy Selection to Clipboard</button>
+  <button id="importBtn">Import from Clipboard</button>
+  <pre id="output"></pre>
+  <button id="closeBtn">Close</button>
+  <script>
+    const exportBtn = document.getElementById('exportBtn');
+    const importBtn = document.getElementById('importBtn');
+    const output = document.getElementById('output');
+    const closeBtn = document.getElementById('closeBtn');
+
+    exportBtn.onclick = () => {
+      parent.postMessage({ pluginMessage: { type: 'export' } }, '*');
+    };
+
+    importBtn.onclick = async () => {
+      try {
+        const text = await navigator.clipboard.readText();
+        const data = JSON.parse(text);
+        parent.postMessage({ pluginMessage: { type: 'import', data } }, '*');
+      } catch (err) {
+        output.textContent = 'Invalid clipboard content';
+      }
+    };
+
+    closeBtn.onclick = () => {
+      parent.postMessage({ pluginMessage: { type: 'close' } }, '*');
+    };
+
+    onmessage = (event) => {
+      const msg = event.data.pluginMessage;
+      if (msg.type === 'exported') {
+        const str = JSON.stringify(msg.data, null, 2);
+        navigator.clipboard.writeText(str);
+        output.textContent = 'Copied to clipboard!';
+      } else if (msg.type === 'imported') {
+        output.textContent = 'Imported!';
+      } else if (msg.type === 'error') {
+        output.textContent = 'Error: ' + msg.message;
+      }
+    };
+  </script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Raw Component Export Import",
+  "id": "figma-raw-component-export-import",
+  "api": "1.0.0",
+  "main": "dist/code.js",
+  "ui": "dist/ui.html"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "figma-raw-component",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "figma-raw-component",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@figma/plugin-typings": "^1.113.0",
+        "typescript": "^5.2.0"
+      }
+    },
+    "node_modules/@figma/plugin-typings": {
+      "version": "1.113.0",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.113.0.tgz",
+      "integrity": "sha512-gasgrtK6XsZmpsWCbE1g7KTLWGCc6teo4alNUDF06OtJ7E9hwOOTMdicueAgghvQJETI+dmWE3IjJfGIPSsdfA==",
+      "dev": true,
+      "license": "MIT License"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "figma-raw-component",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "tsc",
+    "test": "echo 'No tests specified' && exit 0"
+  },
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.113.0",
+    "typescript": "^5.2.0"
+  }
+}

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,0 +1,78 @@
+figma.showUI(__html__, { width: 400, height: 300 });
+
+figma.ui.onmessage = async (msg) => {
+  if (msg.type === 'export') {
+    const node = figma.currentPage.selection[0];
+    if (!node) {
+      figma.ui.postMessage({ type: 'error', message: 'Select a node to export' });
+      return;
+    }
+    const data = nodeToJSON(node);
+    figma.ui.postMessage({ type: 'exported', data });
+  } else if (msg.type === 'import') {
+    const data = msg.data;
+    try {
+      const node = jsonToNode(data);
+      figma.currentPage.appendChild(node);
+      figma.ui.postMessage({ type: 'imported' });
+    } catch (e) {
+      figma.ui.postMessage({ type: 'error', message: 'Import failed' });
+    }
+  } else if (msg.type === 'close') {
+    figma.closePlugin();
+  }
+};
+
+function nodeToJSON(node: SceneNode): any {
+  const obj: any = {
+    id: node.id,
+    type: node.type,
+    name: node.name,
+  };
+  if ('width' in node) obj.width = node.width;
+  if ('height' in node) obj.height = node.height;
+  if ('fills' in node) obj.fills = clone((node as GeometryMixin).fills);
+  if ('characters' in node) obj.characters = (node as TextNode).characters;
+  if ('children' in node) {
+    obj.children = [];
+    for (const child of (node as ChildrenMixin).children) {
+      obj.children.push(nodeToJSON(child));
+    }
+  }
+  return obj;
+}
+
+function jsonToNode(obj: any): SceneNode {
+  let node: SceneNode;
+  switch (obj.type) {
+    case 'RECTANGLE':
+      node = figma.createRectangle();
+      break;
+    case 'TEXT':
+      node = figma.createText();
+      if (obj.characters) (node as TextNode).characters = obj.characters;
+      break;
+    case 'COMPONENT':
+      node = figma.createComponent();
+      break;
+    case 'FRAME':
+    default:
+      node = figma.createFrame();
+      break;
+  }
+  node.name = obj.name || '';
+  if ('width' in obj && 'height' in obj && 'resize' in node)
+    (node as LayoutMixin).resize(obj.width, obj.height);
+  if ('fills' in obj) (node as GeometryMixin).fills = obj.fills;
+  if (obj.children && 'appendChild' in node) {
+    for (const childObj of obj.children) {
+      const child = jsonToNode(childObj);
+      (node as ChildrenMixin).appendChild(child);
+    }
+  }
+  return node;
+}
+
+function clone(value: any) {
+  return JSON.parse(JSON.stringify(value));
+}

--- a/src/ui.html
+++ b/src/ui.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body { font-family: sans-serif; }
+  </style>
+</head>
+<body>
+  <h3>Raw Component Export/Import</h3>
+  <button id="exportBtn">Copy Selection to Clipboard</button>
+  <button id="importBtn">Import from Clipboard</button>
+  <pre id="output"></pre>
+  <button id="closeBtn">Close</button>
+  <script>
+    const exportBtn = document.getElementById('exportBtn');
+    const importBtn = document.getElementById('importBtn');
+    const output = document.getElementById('output');
+    const closeBtn = document.getElementById('closeBtn');
+
+    exportBtn.onclick = () => {
+      parent.postMessage({ pluginMessage: { type: 'export' } }, '*');
+    };
+
+    importBtn.onclick = async () => {
+      try {
+        const text = await navigator.clipboard.readText();
+        const data = JSON.parse(text);
+        parent.postMessage({ pluginMessage: { type: 'import', data } }, '*');
+      } catch (err) {
+        output.textContent = 'Invalid clipboard content';
+      }
+    };
+
+    closeBtn.onclick = () => {
+      parent.postMessage({ pluginMessage: { type: 'close' } }, '*');
+    };
+
+    onmessage = (event) => {
+      const msg = event.data.pluginMessage;
+      if (msg.type === 'exported') {
+        const str = JSON.stringify(msg.data, null, 2);
+        navigator.clipboard.writeText(str);
+        output.textContent = 'Copied to clipboard!';
+      } else if (msg.type === 'imported') {
+        output.textContent = 'Imported!';
+      } else if (msg.type === 'error') {
+        output.textContent = 'Error: ' + msg.message;
+      }
+    };
+  </script>
+</body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "lib": [
+      "es2015"
+    ],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "types": [
+      "@figma/plugin-typings"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- use clipboard instead of file system for plugin export/import

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a688e6c20832d8f1016401328afeb