### PR TITLE
Switch to ES modules

### DIFF
--- a/dist/code.js
+++ b/dist/code.js
@@ -1,4 +1,3 @@
-"use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -8,8 +7,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-Object.defineProperty(exports, "__esModule", { value: true });
-const node_type_props_1 = require("./node-type-props");
+import { NODE_TYPE_PROPS } from './node-type-props.js';
 figma.showUI(__html__, { width: 400, height: 300 });
 figma.ui.onmessage = (msg) => __awaiter(void 0, void 0, void 0, function* () {
     if (msg.type === 'export') {
@@ -38,7 +36,7 @@ figma.ui.onmessage = (msg) => __awaiter(void 0, void 0, void 0, function* () {
 });
 function nodeToJSON(node) {
     const obj = { type: node.type };
-    const props = node_type_props_1.NODE_TYPE_PROPS[node.type] || [];
+    const props = NODE_TYPE_PROPS[node.type] || [];
     for (const key of props) {
         if (key === 'children')
             continue;
@@ -92,7 +90,7 @@ function jsonToNode(obj) {
         }
         catch (_b) { }
     }
-    const props = node_type_props_1.NODE_TYPE_PROPS[obj.type] || [];
+    const props = NODE_TYPE_PROPS[obj.type] || [];
     for (const key of props) {
         if (key === 'children' || key === 'type' || key === 'parent' || key === 'name' || key === 'width' || key === 'height' || key === 'fills')
             continue;

--- a/dist/node-type-props.js
+++ b/dist/node-type-props.js
@@ -1,7 +1,4 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.NODE_TYPE_PROPS = void 0;
-exports.NODE_TYPE_PROPS = {
+export const NODE_TYPE_PROPS = {
     "REMOVED": [
         "id",
         "removed",

--- a/dist/node-types.js
+++ b/dist/node-types.js
@@ -1,7 +1,4 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.NODE_TYPES = void 0;
-exports.NODE_TYPES = [
+export const NODE_TYPES = [
     'DOCUMENT',
     'PAGE',
     'SLICE',

--- a/src/code.ts
+++ b/src/code.ts
@@ -1,4 +1,4 @@
-import { NODE_TYPE_PROPS } from './node-type-props';
+import { NODE_TYPE_PROPS } from './node-type-props.js';
 
 figma.showUI(__html__, { width: 400, height: 300 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "esnext",
     "lib": [
       "es2015",
       "dom"


### PR DESCRIPTION
## Summary
- compile to ESNext modules instead of CommonJS
- adjust import paths for ESM

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c2b067940832d8653e24e2944a60c